### PR TITLE
Adds link to New Contributor Workshop slides

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -12,6 +12,7 @@ PULL REQUESTS ARE WELCOME!
  - [Intro to the cloud-native world of Kubernetes](https://speakerdeck.com/luxas/intro-to-the-cloud-native-world-of-kubernetes-november-2018) by Lucas Käldström ([Kubernetes & CNCF Finland meetup](https://www.meetup.com/Kubernetes-Finland/), Nov 20, 2018)
  - [How to Contribute to Kubernetes](https://docs.google.com/presentation/d/1NJfoXynMw1LXT2jrGm8zaE7uP8Mtz5A0isdzmxISCkk/edit?usp=sharing) by Nikhita Raghunath (KubeCon+CloudNativeCon North America 2017)
  - [Introduction to Kubernetes Workshop (full-day)](https://docs.google.com/presentation/d/1zrfVlE5r61ZNQrmXKx5gJmBcXnoa_WerHEnTxu5SMco/edit?usp=sharing) by Bob Killen and Jeff Sica (July 17, 2018)
+ - [Kubernetes New Contributor Workshop](https://docs.google.com/presentation/d/1cgEw0t8oeokaN44piqmEemul2gQBqZX5wvj6NncqPFI/edit?usp=sharing) by Guinevere Saenger, Josh Berkus, Noah Abrahams, Tim Pepper, Zach Corleissen, and Michelle Shephardson (KubeCon+CloudNativeCon North America 2018)
 
 ### Kubernetes Updates
 


### PR DESCRIPTION
The slide deck from KubeCon Seattle's New Contributor Track at the Kubernetes Contributor Summit is now linked here. Video link to follow once it's on YouTube.