### PR TITLE
Add Cloud Native Barcelona - Contributing to Kubernetes slides

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -13,6 +13,7 @@ PULL REQUESTS ARE WELCOME!
  - [How to Contribute to Kubernetes](https://docs.google.com/presentation/d/1NJfoXynMw1LXT2jrGm8zaE7uP8Mtz5A0isdzmxISCkk/edit?usp=sharing) by Nikhita Raghunath (KubeCon+CloudNativeCon North America 2017)
  - [Introduction to Kubernetes Workshop (full-day)](https://docs.google.com/presentation/d/1zrfVlE5r61ZNQrmXKx5gJmBcXnoa_WerHEnTxu5SMco/edit?usp=sharing) by Bob Killen and Jeff Sica (July 17, 2018)
  - [Intro to Kubernetes - from containers to orchestrating the world](https://docs.google.com/presentation/d/11cFazU6c8tLWdEvmxYAb2DJ6Pht89Xxpqpsiug_aP7E) By Alex Sirbu (March 14, 2019)
+ - [Contributing to Kubernetes - SIG-Docs hackathon](https://docs.google.com/presentation/d/1Gdise-O9oAmJaBiBxqzl7FVmMLKnat0619Mxy-Qh5Uo/edit?usp=sharing) by Rael Garcia (Cloud Native Barcelona - Contributing to Kubernetes - SIG-Docs hackathon 2019)
 
 ### Kubernetes New Contributor Workshops
 - [Kubernetes New Contributor Workshop Seattle](https://docs.google.com/presentation/d/1cgEw0t8oeokaN44piqmEemul2gQBqZX5wvj6NncqPFI/edit?usp=sharing) by Guinevere Saenger, Josh Berkus, Noah Abrahams, Tim Pepper, Zach Corleissen, and Michelle Shephardson (KubeCon+CloudNativeCon North America 2018)


### PR DESCRIPTION
This PR adds the slide deck used during the Cloud Native Barcelona - Contributing to Kubernetes Hackathon.

- Slides

https://docs.google.com/presentation/d/1Gdise-O9oAmJaBiBxqzl7FVmMLKnat0619Mxy-Qh5Uo/edit?usp=sharing

- Event

https://www.meetup.com/Cloud-Native-Barcelona/events/260769421/

/cc @guineveresaenger 