### PR TITLE
fix link to current location on each project

### DIFF
--- a/coredns/README.md
+++ b/coredns/README.md
@@ -25,4 +25,4 @@ If you have your slides already online or hosted someplace else, just leave a li
 Please make sure your content is under the Apache v2.0 or CC-BY license so we can easily share and reuse the content.
 
 - [cncf/presentations](https://github.com/cncf/presentations) - Home to all CNCF project presentations
- - [cncf/presentations/coredns](https://github.com/cncf/presentations/coredns) - you are here
+ - [cncf/presentations/coredns](https://github.com/cncf/presentations/tree/master/coredns) - you are here

--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -19,4 +19,4 @@ If you have your slides already online or hosted someplace else, just leave a li
 Please make sure your content is under the Apache v2.0 or CC-BY license so we can easily share and reuse the content.
 
 [cncf/presentations](https://github.com/cncf/presentations) - Home to all CNCF project presentations
-- [cncf/presentations/fluentd](https://github.com/cncf/presentations/fluentd) - you are here
+- [cncf/presentations/fluentd](https://github.com/cncf/presentations/tree/master/fluentd) - you are here

--- a/linkerd/README.md
+++ b/linkerd/README.md
@@ -15,4 +15,4 @@ If you have your slides already online or hosted someplace else, just leave a li
 Please make sure your content is under the Apache v2.0 or CC-BY license so we can easily share and reuse the content.
 
 [cncf/presentations](https://github.com/cncf/presentations) - Home to all CNCF project presentations
-- [cncf/presentations/linkerd](https://github.com/cncf/presentations/linkerd) - you are here
+- [cncf/presentations/linkerd](https://github.com/cncf/presentations/tree/master/linkerd) - you are here

--- a/opa/README.md
+++ b/opa/README.md
@@ -15,4 +15,4 @@ If you have your slides already online or hosted someplace else, just leave a li
 Please make sure your content is under the Apache v2.0 or CC-BY license so we can easily share and reuse the content.
 
 [cncf/presentations](https://github.com/cncf/presentations) - Home to all CNCF project presentations
-- [cncf/presentations/fluentd](https://github.com/cncf/presentations/fluentd) - you are here
+- [cncf/presentations/fluentd](https://github.com/cncf/presentations/tree/master/fluentd) - you are here

--- a/opentracing/README.md
+++ b/opentracing/README.md
@@ -21,4 +21,4 @@ If you have your slides already online or hosted someplace else, just leave a li
 Please make sure your content is under the Apache v2.0 or CC-BY license so we can easily share and reuse the content.
 
 - [cncf/presentations](https://github.com/cncf/presentations) - Home to all CNCF project presentations
-- [cncf/presentations/opentracing](https://github.com/cncf/presentations/opentracing) - you are here
+- [cncf/presentations/opentracing](https://github.com/cncf/presentations/tree/master/opentracing) - you are here

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -20,4 +20,4 @@ If you have your slides already online or hosted someplace else, just leave a li
 Please make sure your content is under the Apache v2.0 or CC-BY license so we can easily share and reuse the content.
 
 [cncf/presentations](https://github.com/cncf/presentations) - Home to all CNCF project presentations
-- [cncf/presentations/prometheus](https://github.com/cncf/presentations/prometheus) - you are here
+- [cncf/presentations/prometheus](https://github.com/cncf/presentations/tree/master/prometheus) - you are here


### PR DESCRIPTION
Fix issue to where the links on each project would lead to a github 404:

![image](https://user-images.githubusercontent.com/492108/67377166-2b702e00-f57d-11e9-95c7-7310fa6d1a7a.png)

Due to missing branch location as per the following examples:
Previous link: [https://github.com/cncf/presentations/coredns](https://github.com/cncf/presentations/coredns)
Updated link: [https://github.com/cncf/presentations/tree/master/coredns](https://github.com/cncf/presentations/tree/master/coredns)

Signed-off-by: fsschmitt <492108+fsschmitt@users.noreply.github.com>