### PR TITLE
docs(README.md): remove broken URL

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -26,7 +26,7 @@ PULL REQUESTS ARE WELCOME!
 
 ### Kubernetes Concepts and Components
 
-- [Introduction to Kubernetes](https://drive.google.com/file/d/1Lfi8r0GZdFIMgprUrwaf-Lru5RsctML7/view?usp=sharing) by Rishabh Indoria (March 2019)
+- [Introduction to Kubernetes](https://drive.google.com/file/d/1p65kmMRyDL4_r2MWSJLTMAZyMnHEZUXt/view) by Rishabh Indoria (March 2019)
 - [Kubernetes 101](http://slides.eightypercent.net/kubernetes-101/#1) - by Joe Beda (Gluecon 2017)
 - [Edge vs. Level triggered logic](https://speakerdeck.com/thockin/edge-vs-level-triggered-logic) by Tim Hockin
 - [A Crash Course on Container Orchestration](https://speakerdeck.com/thockin/a-crash-course-on-container-orchestration) by Tim Hockin (Interop ITX)


### PR DESCRIPTION
Fix issue with new URL from @rishabhindoria

My understanding is Igor Maksimov noticed this, who wrote at https://cloud-native.slack.com/archives/C08PSKWPN/p1637047839218400?thread_ts=1622556287.103400&cid=C08PSKWPN
> link for
> • Introduction to Kubernetes by Rishabh Indoria (March 2019)
> is broken.