### PR TITLE
Update presentation repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,27 +33,10 @@ Our goal is to collect as many CNCF-related talks as possible. Therefore, the on
 Most of the information related to these talks is publicly available and published on schedules. If you wish to help your friends and colleagues submit their talks to enrich specific topic tags, you're encouraged to do so. However, please consult with the presenter before submitting a PR as a common courtesy.
 
 ## CNCF Overview presentation
-The CNCF overview [presentation](https://docs.google.com/presentation/d/1UGewu4MMYZobunfKr5sOGXsspcLOH_5XeCLyOHKh9LU/) by Dan Kohn is available via Google Docs. It includes the slides for a talk, A Brief History of the Cloud, in the appendix.  
-A Chinese version, updated every month, is available for [download](https://github.com/cncf/presentations/raw/main/chinese/CNCF_Overview_CN.pptx) (PowerPoint).  
-A Japanese version is also [available](https://github.com/cncf/presentations/tree/master/japanese/CNCF_Overview_Ja-Jp.pptx) (PowerPoint).
-A Korean version is also [available](https://github.com/cncf/presentations/tree/master/korean/CNCF_Overview_ko-kr.pptx) (PowerPoint).
-
-CNCF概况介绍每月更新，可以在这下载[PPTX文档](https://github.com/cncf/presentations/raw/main/chinese/CNCF_Overview_CN.pptx)  
-この日本語バージョンは、CNCF overview を @zembutsu が翻訳しました。お気づきの点がありましたらご指摘ください。
-[한국어 버전](https://github.com/cncf/presentations/tree/master/korean/CNCF_Overview_ko-kr.pptx)에 대한 자세한 설명을 여기를 참고하세요: [링크](korean/README.md)
-
-
-### Older Overview presentations
-The 2017 [presentation](https://docs.google.com/presentation/d/105ZgwafitwXH6_sWevFHHUerciuv4ckDQ_CXjGPjv0Y/) (Google Doc) by Dan Kohn, Migrating Legacy Monoliths to Cloud Native Microservices Architectures on Kubernetes, is also available.
-
-The 2018 [presentation](https://docs.google.com/presentation/d/1r3lI5YdLVjSCc6CuHmP-cE0R-Bixx_ejBk-WMVNv1Y8/) (Google Doc) by Dan Kohn, How Good Is Our Code?, is also available in [Chinese](https://github.com/cncf/presentations/blob/master/chinese/How_Good_Is_Our_Code_CN.pptx) (PowerPoint) as well.
-
+The CNCF overview [presentation](https://docs.google.com/presentation/d/1UGewu4MMYZobunfKr5sOGXsspcLOH_5XeCLyOHKh9LU/) is available via Google Docs. 
 
 ## CNCF End User Community Overview presentation
-The CNCF End User Community overview by Cheryl Hung is available in English or Chinese:
-
-* [CNCF End User Community](https://docs.google.com/presentation/d/194SyKdHL7ws_DBOdbrXdowEJi54kIzDdDK_h-6Ag0uo/) (Google Doc)
-* [CNCF 最终用户社区](https://github.com/cncf/presentations/raw/main/chinese/CNCF_EUC_Overview_CN.pptx) (PowerPoint)
+The CNCF End User Community overview [presentation](https://docs.google.com/presentation/d/1HQIIpz5qXdyu2F1Th2ttf_PHxhH7KV7TiLNQ5hHTSl8/edit?slide=id.g313865f5671_4_0#slide=id.g313865f5671_4_0) is available via Google Docs.
 
 ## Other presentations
 Other presentations from the CNCF community are available in this repo, although they may be out of date. Just send us a pull request if you want your presentation added. Please make sure it's under the Apache v2.0 or CC-BY license so we can easily share and reuse the content.

--- a/cncf-archive/README.md
+++ b/cncf-archive/README.md
@@ -1,0 +1,5 @@
+**Archived CNCF Presentations**
+
+[Migrating Legacy Monoliths to Cloud Native Microservices Architectures on Kubernetes](https://docs.google.com/presentation/d/105ZgwafitwXH6_sWevFHHUerciuv4ckDQ_CXjGPjv0Y/) by Dan Kohn (2017)
+
+[How Good Is Our Code?](https://docs.google.com/presentation/d/1r3lI5YdLVjSCc6CuHmP-cE0R-Bixx_ejBk-WMVNv1Y8/) by Dan Kohn (2018)


### PR DESCRIPTION
Updating repo to move older decks to archive and update link to end user deck. Remove decks that are no longer updated.