### PR TITLE
docs: add Crossplane talk from Cloud Native Kuala Lumpur (Feb 2026)

### DIFF
--- a/presentations.yaml
+++ b/presentations.yaml
@@ -83,7 +83,7 @@
   description: |
     This presentation aims to explore the evolving surrounding of gRPC services intercommunication in the context of containers and inside service mesh. It will delve in the history and intricacies of securing communication, authentication, authorization and accounting within a modern distributed system architecture. This talk also emphasize the current crucial role of Istio in enhancing the security posture of gRPC services east-west traffic compared with older approaches, that includes default encryption, identity and access management, and secure service-to-service communication on service mesh without the complexity of sidecars usage.
   video: https://www.youtube.com/watch?v=CdwRy-SwAZI
-  slides: https://docs.google.com/presentation/d/1uXMaTdL12xc1IVAuy66w11D6RQKlj2bo/edit#slide=id.p1
+  #slides: https://docs.google.com/presentation/d/1uXMaTdL12xc1IVAuy66w11D6RQKlj2bo/edit#slide=id.p1
   date: 2022-10-04
   presenters:
     - name: Amim Knabben
@@ -117,7 +117,7 @@
   description: |
     Users don’t care where items run, just IF they run and how long they need to wait for completion. We should be building systems where ONLY the hardware, network, storage, and security engineers worry about how to maximally leverage underlying hardware for performance. Increasingly popular AI/ML and traditional HPC workloads have many similarities. It is historically difficult for the users to deploy their workloads in HPC environments. Kubernetes, meanwhile, has focused on simplifying the cognitive load for the users at a cost to both performance and sustainability. We show how to lift paradigms from HPC to make more performant Kubernetes clusters. We give a history of where HPC has come up short in abstracting hardware away from the user. We highlight current Kubernetes projects that do aid in performance in a cloud-native fashion and will go over continuing gaps. We will show how to improve Kubernetes to optimize both performance and sustainability without added pain to the user.
   video: https://www.youtube.com/watch?v=0iH1HK20obs
-  slides: https://static.sched.com/hosted_files/kubernetesbatchdayna22/68/PropogatingProgammingParadigmsMarlowWestonIntel.pdf?_gl=1*1ikx4yr*_ga*MjEyMzcyMjQ3OS4xNjk2Nzg3NDM5*_ga_XH5XM35VHB*MTY5Njc4NzQzOS4xLjAuMTY5Njc4NzQzOS42MC4wLjA.
+  slides: https://static.sched.com/hosted_files/kubernetesbatchdayna22/68/PropogatingProgammingParadigmsMarlowWestonIntel.pdf
   date: 2023-10-24
   presenters:
     - name: Marlow Weston

--- a/presentations.yaml
+++ b/presentations.yaml
@@ -382,3 +382,18 @@
   tags:
     - Project Maintainer
     - Ambassador
+- name: Building a Kubernetes-native control plane with Crossplane
+  description: |
+    This talk explores how Crossplane can be used to build a Kubernetes-native control plane for platform engineering. It demonstrates how platform teams can define reusable abstractions and offer self-service infrastructure through Kubernetes APIs.
+    The session includes a live demo showing how to create a Crossplane Composition and use it to provision a PostgreSQL database on AWS from Kubernetes. The focus is on how Compositions enable reusable infrastructure patterns and controlled self-service workflows.
+  slides: https://github.com/Vasil-Shaikh/Presentations/blob/main/Building%20a%20Kubernetes-native%20control%20plane%20with%20Crossplane%20(with%20Live%20Demo).pdf
+  date: 2026-02-10
+  presenters:
+    - name: Vasil Shaikh
+      github: Vasil-Shaikh
+  event:
+    name: Cloud Native Kuala Lumpur, Feb 2026 Meetup
+    url: https://community.cncf.io/events/details/cncf-cloud-native-kuala-lumpur-presents-in-person-cloud-native-kuala-lumpur-meetup-february-2026/
+  language: EN
+  projects:
+    - crossplane

--- a/presentations.yaml
+++ b/presentations.yaml
@@ -83,7 +83,7 @@
   description: |
     This presentation aims to explore the evolving surrounding of gRPC services intercommunication in the context of containers and inside service mesh. It will delve in the history and intricacies of securing communication, authentication, authorization and accounting within a modern distributed system architecture. This talk also emphasize the current crucial role of Istio in enhancing the security posture of gRPC services east-west traffic compared with older approaches, that includes default encryption, identity and access management, and secure service-to-service communication on service mesh without the complexity of sidecars usage.
   video: https://www.youtube.com/watch?v=CdwRy-SwAZI
-  #slides: https://docs.google.com/presentation/d/1uXMaTdL12xc1IVAuy66w11D6RQKlj2bo/edit#slide=id.p1
+  slides: https://static.sched.com/hosted_files/istiocon2023/e0/%5Bistiocon%5Dgrpc-securit-istio.pptx
   date: 2022-10-04
   presenters:
     - name: Amim Knabben


### PR DESCRIPTION
This PR adds the presentation for the talk that I delivered during Cloud Native Kuala Lumpur, Feb 2026 Meetup -  https://community.cncf.io/events/details/cncf-cloud-native-kuala-lumpur-presents-in-person-cloud-native-kuala-lumpur-meetup-february-2026/